### PR TITLE
Fixed wrong current stepper position

### DIFF
--- a/DendoStepper.cpp
+++ b/DendoStepper.cpp
@@ -100,7 +100,6 @@ esp_err_t DendoStepper::runPos(int32_t relative)
         enableMotor();
     ctrl.status = ACC;
     setDir(relative < 0); // set CCW if <0, else set CW
-    currentPos += relative;
     calc(abs(relative)); // calculate velocity profile
 
     alarm_cfg.alarm_count = ctrl.stepInterval;
@@ -272,6 +271,16 @@ bool DendoStepper::xISR(gptimer_t *timer, const gptimer_alarm_event_data_t *data
     // add and substract one step
 
     ctrl.stepCnt++;
+
+    // update current position
+    if (ctrl.dir == CW)
+    {
+        currentPos++;
+    }
+    else
+    {
+        currentPos--;
+    }
 
     // we are done
     if (ctrl.stepsToGo == ctrl.stepCnt && !ctrl.runInfinite)


### PR DESCRIPTION
See issue #20.

This fix will have this output:
```
I (380) main: Loop run with stop: false
I (380) main: pos 1: 0
I (390) DendoStepper: Enabled
I (390) calc: acc end:25 coastend:1975 stepstogo:2000 speed:200.000000 acc:800.000000 int: 125000
I (2900) main: pos 2: 10
I (5400) main: pos 3: 23

I (5400) main: Loop run with stop: true
I (5400) main: pos 1: 23
W (5400) DendoStepper: Finising previous move, this command will be ignored
I (7900) main: pos 2: 35
I (10400) main: pos 3: 48

I (10400) main: Loop run with stop: false
I (10400) main: pos 1: 48
I (10400) calc: acc end:25 coastend:1975 stepstogo:2000 speed:200.000000 acc:800.000000 int: 125000
I (12910) main: pos 2: 58
I (15410) main: pos 3: 71

I (15410) main: Loop run with stop: true
I (15410) main: pos 1: 71
W (15410) DendoStepper: Finising previous move, this command will be ignored
I (17910) main: pos 2: 83
I (20410) main: pos 3: 96
``` 